### PR TITLE
Fix pool.d path error

### DIFF
--- a/8.1-fpm/fpm/php-fpm.conf
+++ b/8.1-fpm/fpm/php-fpm.conf
@@ -28,4 +28,4 @@ php_admin_value[sendmail_path] = /usr/local/bin/phpmailer
 php_admin_value[open_basedir]= "/data:/srv:/var/tmp:/tmp"
 php_admin_value[upload_tmp_dir] = "/var/tmp"
 
-include=/etc/php/8.0/fpm/pool.d/*.conf
+include=/etc/php/8.1/fpm/pool.d/*.conf


### PR DESCRIPTION
ERROR: Unable to globalize '/etc/php/8.0/fpm/pool.d/*.conf' (ret=2) from /etc/php/8.1/fpm/php-fpm.conf at line 31.