### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,14 +13,41 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        item: ["8.5", "8.5-fpm"]
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build image"
+        uses: docker/build-push-action@v6
+        with:
+          context: "${{ matrix.item }}"
+          load: true
+          tags: "dockette/php:${{ matrix.item }}"
+
+      - name: "Test image"
+        run: "make test-${{ matrix.item }}"
+
   build:
     name: "Build"
+    needs: ["test"]
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:
-        image: "dockette/php"
-        tag: "${{ matrix.item }}"
-        context: "${{ matrix.item }}"
+      image: "dockette/php"
+      tag: "${{ matrix.item }}"
+      context: "${{ matrix.item }}"
     strategy:
       matrix:
         include:
@@ -50,3 +77,20 @@ jobs:
           - item: "8.5-fpm"
 
       fail-fast: false
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/php"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 DOCKER_IMAGE=dockette/php
 DOCKER_PLATFORM?=linux/amd64
+VERSION?=8.5
+
+.PHONY: build test run test-%
+
+build: build-${VERSION}
+
+test: test-${VERSION} test-${VERSION}-fpm
+
+run:
+	docker run --rm -it -v ${PWD}:/srv ${DOCKER_IMAGE}:${VERSION}
 
 _build-%: VERSION=$*
 _build-%:
@@ -34,3 +44,8 @@ build-8.4: _build-8.4
 build-8.4-fpm: _build-8.4-fpm
 build-8.5: _build-8.5
 build-8.5-fpm: _build-8.5-fpm
+
+test-%:
+	docker run --rm ${DOCKER_IMAGE}:$* php -v
+	docker run --rm ${DOCKER_IMAGE}:$* composer --version
+	if echo "$*" | grep -q -- '-fpm$$'; then docker run --rm ${DOCKER_IMAGE}:$* php-fpm -t; fi

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,4 @@ build-8.5: _build-8.5
 build-8.5-fpm: _build-8.5-fpm
 
 test-%:
-	docker run --rm ${DOCKER_IMAGE}:$* php -v
-	docker run --rm ${DOCKER_IMAGE}:$* composer --version
-	if echo "$*" | grep -q -- '-fpm$$'; then docker run --rm ${DOCKER_IMAGE}:$* php-fpm -t; fi
+	docker run --rm ${DOCKER_IMAGE}:$* sh -lc 'php -v && composer --version && case "$*" in *-fpm) php-fpm -t ;; esac'

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 </p>
 
 <p align=center>
-  <a href="https://hub.docker.com/r/dockette/php/"><img src="https://badgen.net/docker/pulls/dockette/php"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://github.com/sponsors/f3l1x"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
+   <a href="https://github.com/dockette/php/actions"><img src="https://github.com/dockette/php/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/php"><img src="https://img.shields.io/docker/pulls/dockette/php.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
 </p>
 
 -----
@@ -54,7 +55,7 @@ docker run -v /path/to/site:/srv dockette/php:5.6-fpm
 ```Dockerfile
 FROM dockette/php:8.5-fpm
 
-RUN apt update && apt install -y curl 
+RUN apt update && apt install -y curl
 ```
 
 ## Documentation
@@ -79,16 +80,6 @@ In case of customization PHP 5.6 - 8.5:
 
 - /etc/php/{5.6-8.5}/{cli,cgi,fpm}/conf.d/991-custom.ini
 
-## Development
+## Maintenance
 
-See [how to contribute](https://contributte.org/contributing.html) to this package.
-
-This package is currently maintaining by these authors.
-
-<a href="https://github.com/f3l1x">
-    <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
-</a>
-
------
-
-Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Also thank you for using this package.
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.


### PR DESCRIPTION
What changed
- Added a cheap Docker smoke-test job before the reusable build matrix.
- Added Docker Hub description publishing through a Docs job.
- Added default Makefile build, test, and run targets while preserving versioned builds.
- Normalized README badges to the Dockette Copybara style and added the standard Maintenance section.

Why
- Establishes the Dockette CI rollout baseline for dockette/php with representative PHP, Composer, and FPM checks before publishing images.