### PR TITLE
Fix phpdbg symlink setup

### DIFF
--- a/5.6-fpm/Dockerfile
+++ b/5.6-fpm/Dockerfile
@@ -56,7 +56,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg5.6 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -52,7 +52,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg5.6 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/7.0-fpm/Dockerfile
+++ b/7.0-fpm/Dockerfile
@@ -56,7 +56,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.0 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -52,7 +52,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.0 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/7.1-fpm/Dockerfile
+++ b/7.1-fpm/Dockerfile
@@ -56,7 +56,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.1 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -52,7 +52,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.1 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/7.2-fpm/Dockerfile
+++ b/7.2-fpm/Dockerfile
@@ -54,7 +54,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.2 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -50,7 +50,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.2 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/7.3-fpm/Dockerfile
+++ b/7.3-fpm/Dockerfile
@@ -53,7 +53,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.3 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -49,7 +49,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.3 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/7.4-fpm/Dockerfile
+++ b/7.4-fpm/Dockerfile
@@ -53,7 +53,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.4 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -49,7 +49,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg7.4 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/8.0-fpm/Dockerfile
+++ b/8.0-fpm/Dockerfile
@@ -52,7 +52,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.0 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -48,7 +48,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.0 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/8.1-fpm/Dockerfile
+++ b/8.1-fpm/Dockerfile
@@ -52,7 +52,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.1 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -48,7 +48,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.1 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/8.2-fpm/Dockerfile
+++ b/8.2-fpm/Dockerfile
@@ -51,7 +51,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.2 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -47,7 +47,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.2 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/8.3-fpm/Dockerfile
+++ b/8.3-fpm/Dockerfile
@@ -51,7 +51,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.3 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -47,7 +47,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.3 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/8.4-fpm/Dockerfile
+++ b/8.4-fpm/Dockerfile
@@ -51,7 +51,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.4 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -47,7 +47,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.4 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################

--- a/8.5-fpm/Dockerfile
+++ b/8.5-fpm/Dockerfile
@@ -51,7 +51,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.5 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -47,7 +47,6 @@ RUN apt update && apt dist-upgrade -y && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # PHP MOD(s) ###############################################################
-    ln -s /usr/bin/phpdbg8.5 /usr/bin/phpdbg && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
     ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
     # CLEAN UP #################################################################


### PR DESCRIPTION
## Summary
- remove manual /usr/bin/phpdbg symlink creation from all PHP Dockerfiles
- rely on phpdbg package alternatives, which now create the generic phpdbg command

## Verification
- inspected failing job log: /usr/bin/phpdbg already exists after installing php8.5-phpdbg
- confirmed no Dockerfile still creates /usr/bin/phpdbg manually
- local Docker build could not be run because the Docker daemon is unavailable in this workspace